### PR TITLE
Bump version to v0.200.1

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -33,7 +33,7 @@ runs:
       shell: bash
       run: bash $GITHUB_ACTION_PATH/setup_release.sh
       env:
-        VERSION: 0.100.2
+        VERSION: 0.200.1
 
     - name: Get Databricks CLI version
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -37,4 +37,4 @@ runs:
 
     - name: Get Databricks CLI version
       shell: bash
-      run: databricks version --detail | jq .
+      run: databricks version --output json | jq .

--- a/action.yml
+++ b/action.yml
@@ -37,4 +37,4 @@ runs:
 
     - name: Get Databricks CLI version
       shell: bash
-      run: databricks version --output json | jq .
+      run: databricks version --output json

--- a/install.sh
+++ b/install.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-VERSION="0.100.2"
+VERSION="0.200.1"
 FILE="databricks_cli_$VERSION"
 
 # Include operating system in file name.
@@ -64,7 +64,7 @@ fi
 cd "$(mktemp -d)"
 
 # Download release archive.
-curl -s -O "https://databricks-bricks.s3.amazonaws.com/v${VERSION}/${FILE}.zip"
+curl -s -O "https://github.com/databricks/cli/releases/download/v${VERSION}/${FILE}.zip"
 
 # Unzip release archive.
 unzip -q "${FILE}.zip"

--- a/install.sh
+++ b/install.sh
@@ -64,7 +64,7 @@ fi
 cd "$(mktemp -d)"
 
 # Download release archive.
-curl -s -O "https://github.com/databricks/cli/releases/download/v${VERSION}/${FILE}.zip"
+curl -L -s -O "https://github.com/databricks/cli/releases/download/v${VERSION}/${FILE}.zip"
 
 # Unzip release archive.
 unzip -q "${FILE}.zip"

--- a/setup_release.sh
+++ b/setup_release.sh
@@ -39,7 +39,7 @@ ARM64)
 esac
 
 # Download release archive.
-curl -s -O "https://databricks-bricks.s3.amazonaws.com/v${VERSION}/${FILE}.zip"
+curl -s -O "https://github.com/databricks/cli/releases/download/v${VERSION}/${FILE}.zip"
 
 # Unzip release archive.
 unzip -q "${FILE}.zip" -d .bin

--- a/setup_release.sh
+++ b/setup_release.sh
@@ -39,7 +39,7 @@ ARM64)
 esac
 
 # Download release archive.
-curl -s -O "https://github.com/databricks/cli/releases/download/v${VERSION}/${FILE}.zip"
+curl -L -s -O "https://github.com/databricks/cli/releases/download/v${VERSION}/${FILE}.zip"
 
 # Unzip release archive.
 unzip -q "${FILE}.zip" -d .bin


### PR DESCRIPTION
* Update the CLI to v0.200.1
* Update the URL to download binaries from
* Use `--output json` when calling `databricks version`