### PR TITLE
Cleanup temporary directory in install script

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,6 +1,6 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
-set -e
+set -euo pipefail
 
 VERSION="0.200.1"
 FILE="databricks_cli_$VERSION"
@@ -61,7 +61,9 @@ if [ -f "$TARGET/databricks" ]; then
 fi
 
 # Change into temporary directory.
-cd "$(mktemp -d)"
+tmpdir="$(mktemp -d)"
+cd "$tmpdir"
+trap "rm -rf $tmpdir" EXIT
 
 # Download release archive.
 curl -L -s -O "https://github.com/databricks/cli/releases/download/v${VERSION}/${FILE}.zip"

--- a/install.sh
+++ b/install.sh
@@ -62,8 +62,7 @@ fi
 
 # Change into temporary directory.
 tmpdir="$(mktemp -d)"
-cd "$tmpdir"
-trap "rm -rf $tmpdir" EXIT
+pushd "$tmpdir" > /dev/null
 
 # Download release archive.
 curl -L -s -O "https://github.com/databricks/cli/releases/download/v${VERSION}/${FILE}.zip"
@@ -75,3 +74,7 @@ unzip -q "${FILE}.zip"
 chmod +x ./databricks
 cp ./databricks "$TARGET"
 echo "Installed $($TARGET/databricks -v) at $TARGET/databricks."
+
+# Clean up temporary directory.
+popd > /dev/null
+rm -rf "$tmpdir" || true

--- a/install.sh
+++ b/install.sh
@@ -1,6 +1,8 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
-set -euo pipefail
+# Note: we cannot assume we're running bash and use the set -euo pipefail approach.
+# Usage in the wild uses the "curl | sh" approach and we need that to continue working.
+set -e
 
 VERSION="0.200.1"
 FILE="databricks_cli_$VERSION"

--- a/install.sh
+++ b/install.sh
@@ -64,7 +64,7 @@ fi
 
 # Change into temporary directory.
 tmpdir="$(mktemp -d)"
-pushd "$tmpdir" > /dev/null
+cd "$tmpdir"
 
 # Download release archive.
 curl -L -s -O "https://github.com/databricks/cli/releases/download/v${VERSION}/${FILE}.zip"
@@ -78,5 +78,5 @@ cp ./databricks "$TARGET"
 echo "Installed $($TARGET/databricks -v) at $TARGET/databricks."
 
 # Clean up temporary directory.
-popd > /dev/null
+cd "$OLDPWD"
 rm -rf "$tmpdir" || true


### PR DESCRIPTION
This addresses comments from @fjakobs in #18.

We cannot assume we're running bash and use the `set -euo pipefail` approach.
Usage in the wild uses the "curl | sh" approach and we need that to continue working.