### PR TITLE
Add version parameter to action

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ on:
       - main
 
 jobs:
-  release:
+  action_with_defaults:
     runs-on: ${{ matrix.os }}
 
     strategy:
@@ -30,7 +30,33 @@ jobs:
       - run: databricks version
         shell: bash
 
-      - run: ./setup-cli/test.sh
+      - run: ./setup-cli/test.sh $(cat ./setup-cli/VERSION)
+        shell: bash
+
+  action_with_version:
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - macos-latest
+          - ubuntu-latest
+          - windows-latest
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          path: ./setup-cli
+
+      - uses: ./setup-cli
+        with:
+          version: 0.200.0
+
+      - run: databricks version
+        shell: bash
+
+      - run: ./setup-cli/test.sh 0.200.0
         shell: bash
 
   install:
@@ -58,7 +84,7 @@ jobs:
       - run: databricks version
         shell: bash
 
-      - run: ./setup-cli/test.sh
+      - run: ./setup-cli/test.sh $(cat ./setup-cli/VERSION)
         shell: bash
 
   curl:
@@ -83,5 +109,5 @@ jobs:
       - run: databricks version
         shell: bash
 
-      - run: ./setup-cli/test.sh
+      - run: ./setup-cli/test.sh $(cat ./setup-cli/VERSION)
         shell: bash

--- a/action.yml
+++ b/action.yml
@@ -4,6 +4,11 @@ description: |
   Download the latest Databricks CLI snapshot build and add it to $PATH.
 
 inputs:
+  version:
+    description: 'The version of the Databricks CLI to download (defaults to "latest").'
+    default: 'latest'
+    required: false
+
   snapshot:
     description: 'Install a snapshot build (set to "true" to enable).'
     required: false
@@ -28,7 +33,7 @@ runs:
       shell: bash
       run: bash $GITHUB_ACTION_PATH/setup_release.sh
       env:
-        VERSION: 0.203.0
+        VERSION: ${{ inputs.version }}
 
     - name: Get Databricks CLI version
       shell: bash

--- a/setup_release.sh
+++ b/setup_release.sh
@@ -7,6 +7,11 @@ if test -d .bin; then
   exit 0
 fi
 
+# Pull latest version from VERSION file if not set.
+if [ "${VERSION}" == "latest" ]; then
+    VERSION=$(cat $(dirname $0)/VERSION)
+fi
+
 FILE="databricks_cli_$VERSION"
 
 # Include operating system in file name.

--- a/test.sh
+++ b/test.sh
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-EXPECTED=$(cat $(dirname $0)/VERSION)
+EXPECTED="${1:-invalid}"
 ACTUAL=$(databricks version --output json | jq -r .Version)
 
 if [[ "$EXPECTED" != "$ACTUAL" ]]; then


### PR DESCRIPTION
If not specified, this defaults to "latest" and uses the version encoded in the `VERSION` file.

Otherwise, it downloads and installs the specified version.

Closes #30.