### PR TITLE
Add workflow to create tags for versions

### DIFF
--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -1,0 +1,31 @@
+name: test
+
+on:
+  # Update tags on every push to main.
+  push:
+    branches:
+      - main
+
+  # To allow for manual testing.
+  workflow_dispatch:
+
+jobs:
+  tag:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-tags: true
+
+      - shell: bash
+        run: |
+          set -ex
+          commits=$(git log --pretty=format:"%h" ./VERSION)
+          for commit in $commits; do
+              version=$(git show $commit:./VERSION)
+              git tag "v${version}" $commit
+          done
+
+      - shell: bash
+        run: git push --tags


### PR DESCRIPTION
On push to main, iterate over all commits that have changed the VERSION file and tag those commits with its contents.

Closes #35.