### PR TITLE
Fix usage instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This is a composite GitHub Action that sets up the Databricks CLI (preview versi
 In your GitHub Actions workflow, use the following step:
 
 ```yml
-- uses: databricks/setup-cli
+- uses: databricks/setup-cli@main
 ```
 
 <!--


### PR DESCRIPTION
the `uses' attribute must be a path, a Docker image, or owner/repo@ref