### PR TITLE
Update action to not taint the working directory

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,6 +34,9 @@ jobs:
       - run: ./setup-cli/assert/version.sh $(cat ./setup-cli/VERSION)
         shell: bash
 
+      - run: ./setup-cli/assert/clean.sh
+        shell: bash
+
   action_with_version:
     runs-on: ${{ matrix.os }}
 
@@ -58,6 +61,9 @@ jobs:
         shell: bash
 
       - run: ./setup-cli/assert/version.sh 0.200.0
+        shell: bash
+
+      - run: ./setup-cli/assert/clean.sh
         shell: bash
 
   install:

--- a/assert/clean.sh
+++ b/assert/clean.sh
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 function list_files() {
-    find . -not -path './setup-cli*'
+    find . -not -path '.' -not -path './setup-cli*'
 }
 
 # The ./setup-cli path is expected to be present.

--- a/assert/clean.sh
+++ b/assert/clean.sh
@@ -7,7 +7,7 @@ function list_files() {
 }
 
 # The ./setup-cli path is expected to be present.
-if test -n "$(list_files)" ; then
+if [[ "$(list_files)" != "" ]]; then
     echo "Found unexpected files in working directory:"
     list_files
     exit 1

--- a/assert/clean.sh
+++ b/assert/clean.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+function list_files() {
+    find . -not -path './setup-cli*'
+}
+
+# The ./setup-cli path is expected to be present.
+if test -n "$(list_files)" ; then
+    echo "Found unexpected files in working directory:"
+    list_files
+    exit 1
+else
+    exit 0
+fi

--- a/setup_release.sh
+++ b/setup_release.sh
@@ -2,11 +2,6 @@
 
 set -euo pipefail
 
-if test -d .bin; then
-  echo "Directory .bin found; assuming CLI was already downloaded"
-  exit 0
-fi
-
 # Pull latest version from VERSION file if not set.
 if [ -z "${VERSION:-}" ]; then
     VERSION=$(cat "$(dirname "$0")"/VERSION)
@@ -42,6 +37,9 @@ ARM64)
     FILE="${FILE}_arm64"
 ;;
 esac
+
+# Change into temporary directory.
+cd "$RUNNER_TEMP"
 
 # Download release archive.
 curl -L -s -O "https://github.com/databricks/cli/releases/download/v${VERSION}/${FILE}.zip"

--- a/setup_snapshot.sh
+++ b/setup_snapshot.sh
@@ -38,11 +38,6 @@ function cli_snapshot_directory() {
     echo $dir
 }
 
-if test -d .bin; then
-  echo "Directory .bin found; assuming CLI was already downloaded"
-  exit 0
-fi
-
 # Default to main branch if branch is not specified.
 if [ -z "$BRANCH" ]; then
   BRANCH=main
@@ -70,6 +65,9 @@ macOS)
     artifact="cli_darwin_snapshot"
     ;;
 esac
+
+# Change into temporary directory.
+cd "$RUNNER_TEMP"
 
 gh run download "$last_successful_run_id" -n "$artifact" -D .bin
 


### PR DESCRIPTION
Issue #97 indicates that the action leaves files behind in the working directory.

This change updates the action to use `$RUNNER_TEMP`, per https://docs.github.com/en/actions/learn-github-actions/variables#default-environment-variables.