### PR TITLE
Migrate to self-hosted runners

### DIFF
--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -10,7 +10,9 @@ on:
 
 jobs:
   release-pr:
-    runs-on: ubuntu-latest
+    runs-on:
+      group: databricks-protected-runner-group
+      labels: linux-ubuntu-latest
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -11,7 +11,9 @@ on:
 
 jobs:
   tag:
-    runs-on: ubuntu-latest
+    runs-on:
+      group: databricks-protected-runner-group
+      labels: linux-ubuntu-latest
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,6 +9,12 @@ on:
 
   workflow_dispatch:
 
+# Note: all jobs in this workflow run on GitHub-hosted runners.
+# None of them need authenticated (token) access to the repository.
+#
+# If this were to change and they do need authenticated access, make sure to use the
+# self-hosted runners listed on the "Settings" -> "Actions" -> "Runners" page.
+#
 jobs:
   action_with_defaults:
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
As part of security hardening, only runners on an allowlist can perform authenticated operations. The "release-pr" and "tag" workflows require authenticated access to the repository for creating PRs and pushing tags, respectively. Migrate those to run on self-hosted runners.