### PR TITLE
Make curl in install scripts show errors and exit with non-zero status

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -80,7 +80,7 @@ tmpdir="$(mktemp -d)"
 cd "$tmpdir"
 
 # Download release archive.
-curl -L -s -O "https://github.com/databricks/cli/releases/download/v${VERSION}/${FILE}.zip"
+curl -fsSL -O "https://github.com/databricks/cli/releases/download/v${VERSION}/${FILE}.zip"
 
 # Unzip release archive.
 unzip -q "${FILE}.zip"

--- a/setup_release.sh
+++ b/setup_release.sh
@@ -42,7 +42,7 @@ esac
 cd "$RUNNER_TEMP"
 
 # Download release archive.
-curl -L -s -O "https://github.com/databricks/cli/releases/download/v${VERSION}/${FILE}.zip"
+curl -fsSL -O "https://github.com/databricks/cli/releases/download/v${VERSION}/${FILE}.zip"
 
 # Unzip release archive.
 unzip -q "${FILE}.zip" -d .bin


### PR DESCRIPTION
Only `-f` and `-S` are new.

Both these new flags could potentially have surfaced an underlying issue in https://github.com/databricks/cli/issues/2307.

With this change, all curl invocations in this repo use the same set of flags.

Description:

* `-f` / `--fail`
Silently fails on HTTP errors (e.g., 404, 500). Prevents output of error pages to stdout/stderr, returning exit code 22 instead. Critical for scripting to avoid processing invalid responses.

* `-s` / `--silent`
Suppresses progress meters, error messages, and other non-essential output. Ensures clean output for piping or saving to files.

* `-S` / `--show-error`
Overrides -s to display errors if they occur. Balances silent operation with actionable error reporting.

* `-L` / `--location`
Follows HTTP redirects (3xx responses). Essential for URLs that point to mirrored or updated resources (e.g., download links that redirect to CDNs).
