### PR TITLE
Automatically update the CLI version in the README

### DIFF
--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -24,7 +24,7 @@ jobs:
         run: |
           echo "${{ github.event.inputs.version }}" > VERSION
           sed -i -E "s/VERSION=(.*)/VERSION=\"${{ github.event.inputs.version }}\"/" install.sh
-          sed -i -E "s/\d+\.\d+\.\d+/${{ github.event.inputs.version }}/g" README.md
+          sed -i -E "s/[0-9]+\.[0-9]+\.[0-9]+/${{ github.event.inputs.version }}/g" README.md
 
       - name: Create a release pull request
         id: cpr

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -24,6 +24,7 @@ jobs:
         run: |
           echo "${{ github.event.inputs.version }}" > VERSION
           sed -i -E "s/VERSION=(.*)/VERSION=\"${{ github.event.inputs.version }}\"/" install.sh
+          sed -i -E "s/\d+\.\d+\.\d+/${{ github.event.inputs.version }}/g" README.md
 
       - name: Create a release pull request
         id: cpr


### PR DESCRIPTION
The configuration for pinning a specific version that readers are likely to copy-paste should always suggest using the latest version of the CLI.

Closes #138.