### PR TITLE
Use install -m 755 for explicit binary mode

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -85,9 +85,8 @@ curl -fsSL -O "https://github.com/databricks/cli/releases/download/v${VERSION}/$
 # Unzip release archive.
 unzip -q "${FILE}.zip"
 
-# Add databricks to path.
-chmod +x ./databricks
-cp ./databricks "$TARGET"
+# Install at 0755, independent of umask.
+install -m 755 ./databricks "$TARGET/"
 echo "Installed $("$TARGET/databricks" -v) at $TARGET/databricks."
 
 # Clean up temporary directory.


### PR DESCRIPTION
The script currently sets the binary mode in two steps:

```sh
chmod +x ./databricks
cp ./databricks "$TARGET"
```

Under restrictive umasks such as 0027, this leaves the installed binary at mode 0750 instead of 0755 — non-root users cannot execute it.

Two compounding causes:

- `chmod +x` without a `u`/`g`/`o`/`a` actor letter is umask-aware: under 0027 it adds `x` only for owner and group, producing 0750.
- `cp` without `-p` further masks the resulting mode through umask, so even a 0755 source would land as 0750.

This patch replaces both lines with:

```sh
install -m 755 ./databricks "$TARGET/"
```

`install -m 755` sets the mode atomically and ignores umask — the standard pattern for installer scripts.

Verified that the binary lands as 0755 under umask 0027 and that a non-root user can execute it after `sudo sh install.sh`.