### PR TITLE
Support invoking the action twice in the same job

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -72,6 +72,43 @@ jobs:
       - run: ./setup-cli/assert/clean.sh
         shell: bash
 
+  action_twice:
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - macos-latest
+          - ubuntu-latest
+          - windows-latest
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          path: ./setup-cli
+
+      # Confirm the action can be invoked more than once in the same job, and
+      # that each invocation resolves to its own binary.
+      - uses: ./setup-cli
+
+      - run: echo $(which databricks)
+        shell: bash
+
+      - uses: ./setup-cli
+
+      - run: echo $(which databricks)
+        shell: bash
+
+      - run: databricks version
+        shell: bash
+
+      - run: ./setup-cli/assert/version.sh $(cat ./setup-cli/VERSION)
+        shell: bash
+
+      - run: ./setup-cli/assert/clean.sh
+        shell: bash
+
   install:
     runs-on: ${{ matrix.os }}
 

--- a/setup_release.sh
+++ b/setup_release.sh
@@ -39,7 +39,9 @@ ARM64)
 esac
 
 # Use a unique directory per invocation so repeated calls in the same job (and
-# other tools using $RUNNER_TEMP) don't collide.
+# other tools using $RUNNER_TEMP) don't collide. $RUNNER_TEMP is emptied at the
+# beginning and end of each job, so it needs no manual cleanup. See:
+# https://docs.github.com/en/actions/reference/workflows-and-actions/variables
 dir="$(mktemp -d "$RUNNER_TEMP/databricks.XXXXXX")"
 cd "$dir"
 

--- a/setup_release.sh
+++ b/setup_release.sh
@@ -39,10 +39,11 @@ ARM64)
 esac
 
 # Use a unique directory per invocation so repeated calls in the same job (and
-# other tools using $RUNNER_TEMP) don't collide. $RUNNER_TEMP is emptied at the
-# beginning and end of each job, so it needs no manual cleanup.
+# other tools using $RUNNER_TEMP) don't collide.
 #
-# See https://docs.github.com/en/actions/reference/workflows-and-actions/variables
+# $RUNNER_TEMP is emptied at the beginning and end of each job, so it needs no
+# manual cleanup; see
+# https://docs.github.com/en/actions/reference/workflows-and-actions/variables
 dir="$(mktemp -d "$RUNNER_TEMP/databricks.XXXXXX")"
 cd "$dir"
 

--- a/setup_release.sh
+++ b/setup_release.sh
@@ -39,10 +39,8 @@ ARM64)
 esac
 
 # Use a unique directory per invocation so repeated calls in the same job (and
-# other tools using $RUNNER_TEMP) don't collide.
-#
-# $RUNNER_TEMP is emptied at the beginning and end of each job, so it needs no
-# manual cleanup; see
+# other tools using $RUNNER_TEMP) don't collide. $RUNNER_TEMP is emptied at the
+# beginning and end of each job, so it needs no manual cleanup; see
 # https://docs.github.com/en/actions/reference/workflows-and-actions/variables
 dir="$(mktemp -d "$RUNNER_TEMP/databricks.XXXXXX")"
 cd "$dir"

--- a/setup_release.sh
+++ b/setup_release.sh
@@ -40,8 +40,9 @@ esac
 
 # Use a unique directory per invocation so repeated calls in the same job (and
 # other tools using $RUNNER_TEMP) don't collide. $RUNNER_TEMP is emptied at the
-# beginning and end of each job, so it needs no manual cleanup. See:
-# https://docs.github.com/en/actions/reference/workflows-and-actions/variables
+# beginning and end of each job, so it needs no manual cleanup.
+#
+# See https://docs.github.com/en/actions/reference/workflows-and-actions/variables
 dir="$(mktemp -d "$RUNNER_TEMP/databricks.XXXXXX")"
 cd "$dir"
 

--- a/setup_release.sh
+++ b/setup_release.sh
@@ -38,16 +38,17 @@ ARM64)
 ;;
 esac
 
-# Change into temporary directory.
-cd "$RUNNER_TEMP"
+# Use a unique directory per invocation so repeated calls in the same job (and
+# other tools using $RUNNER_TEMP) don't collide.
+dir="$(mktemp -d "$RUNNER_TEMP/databricks.XXXXXX")"
+cd "$dir"
 
 # Download release archive.
 curl -fsSL -O "https://github.com/databricks/cli/releases/download/v${VERSION}/${FILE}.zip"
 
 # Unzip release archive.
-unzip -q "${FILE}.zip" -d .bin
+unzip -q "${FILE}.zip"
 
 # Add databricks to path.
-dir=$PWD/.bin
 chmod +x "${dir}/databricks"
 echo "$dir" >> "$GITHUB_PATH"

--- a/setup_snapshot.sh
+++ b/setup_snapshot.sh
@@ -66,12 +66,15 @@ macOS)
     ;;
 esac
 
-# Change into temporary directory.
-cd "$RUNNER_TEMP"
+# Use a unique directory per invocation so repeated calls in the same job (and
+# other tools using $RUNNER_TEMP) don't collide. An empty directory also keeps
+# "gh run download" and the Windows rename below working on repeat calls.
+tmpdir="$(mktemp -d "$RUNNER_TEMP/databricks.XXXXXX")"
+cd "$tmpdir"
 
-gh run download "$last_successful_run_id" -n "$artifact" -D .bin
+gh run download "$last_successful_run_id" -n "$artifact" -D .
 
-dir="$PWD/.bin/$(cli_snapshot_directory)"
+dir="$PWD/$(cli_snapshot_directory)"
 
 if [ ! -d "$dir" ]; then
     echo "Directory does not exist: $dir"

--- a/setup_snapshot.sh
+++ b/setup_snapshot.sh
@@ -70,8 +70,9 @@ esac
 # other tools using $RUNNER_TEMP) don't collide. An empty directory also keeps
 # "gh run download" and the Windows rename below working on repeat calls.
 # $RUNNER_TEMP is emptied at the beginning and end of each job, so it needs no
-# manual cleanup. See:
-# https://docs.github.com/en/actions/reference/workflows-and-actions/variables
+# manual cleanup.
+#
+# See https://docs.github.com/en/actions/reference/workflows-and-actions/variables
 tmpdir="$(mktemp -d "$RUNNER_TEMP/databricks.XXXXXX")"
 cd "$tmpdir"
 

--- a/setup_snapshot.sh
+++ b/setup_snapshot.sh
@@ -67,11 +67,8 @@ macOS)
 esac
 
 # Use a unique directory per invocation so repeated calls in the same job (and
-# other tools using $RUNNER_TEMP) don't collide. An empty directory also keeps
-# "gh run download" and the Windows rename below working on repeat calls.
-#
-# $RUNNER_TEMP is emptied at the beginning and end of each job, so it needs no
-# manual cleanup; see
+# other tools using $RUNNER_TEMP) don't collide. $RUNNER_TEMP is emptied at the
+# beginning and end of each job, so it needs no manual cleanup; see
 # https://docs.github.com/en/actions/reference/workflows-and-actions/variables
 tmpdir="$(mktemp -d "$RUNNER_TEMP/databricks.XXXXXX")"
 cd "$tmpdir"

--- a/setup_snapshot.sh
+++ b/setup_snapshot.sh
@@ -69,6 +69,9 @@ esac
 # Use a unique directory per invocation so repeated calls in the same job (and
 # other tools using $RUNNER_TEMP) don't collide. An empty directory also keeps
 # "gh run download" and the Windows rename below working on repeat calls.
+# $RUNNER_TEMP is emptied at the beginning and end of each job, so it needs no
+# manual cleanup. See:
+# https://docs.github.com/en/actions/reference/workflows-and-actions/variables
 tmpdir="$(mktemp -d "$RUNNER_TEMP/databricks.XXXXXX")"
 cd "$tmpdir"
 

--- a/setup_snapshot.sh
+++ b/setup_snapshot.sh
@@ -69,10 +69,10 @@ esac
 # Use a unique directory per invocation so repeated calls in the same job (and
 # other tools using $RUNNER_TEMP) don't collide. An empty directory also keeps
 # "gh run download" and the Windows rename below working on repeat calls.
-# $RUNNER_TEMP is emptied at the beginning and end of each job, so it needs no
-# manual cleanup.
 #
-# See https://docs.github.com/en/actions/reference/workflows-and-actions/variables
+# $RUNNER_TEMP is emptied at the beginning and end of each job, so it needs no
+# manual cleanup; see
+# https://docs.github.com/en/actions/reference/workflows-and-actions/variables
 tmpdir="$(mktemp -d "$RUNNER_TEMP/databricks.XXXXXX")"
 cd "$tmpdir"
 


### PR DESCRIPTION
Calling the action twice in one job failed: both runs shared `$RUNNER_TEMP/.bin`, so the second `unzip` hit a non-interactive overwrite prompt and exited 1.

Each invocation now downloads into its own `mktemp -d "$RUNNER_TEMP/databricks.XXXXXX"` dir. A unique per-invocation dir keeps us fully isolated from other actions sharing `$RUNNER_TEMP`, and lets repeated calls coexist without deleting anything.

- `setup_release.sh` / `setup_snapshot.sh`: unique temp dir per invocation.
- `test.yml`: new `action_twice` job (macOS/Ubuntu/Windows) invokes the action twice and asserts version + clean tree.

Closes #186
Closes #136

This pull request and its description were written by Isaac.